### PR TITLE
show the user-device-name in device list when available - issue #5

### DIFF
--- a/app/src/main/java/wseemann/media/romote/adapter/DeviceAdapter.java
+++ b/app/src/main/java/wseemann/media/romote/adapter/DeviceAdapter.java
@@ -85,7 +85,12 @@ public class DeviceAdapter extends ArrayAdapter<Device> {
         roundedBitmapDrawable.setCornerRadius(Math.max(image.getWidth(), image.getHeight()) / 2.0f);
         holder.mIcon.setImageDrawable(roundedBitmapDrawable);
 
-        holder.mText1.setText(device.getModelName()); //device.getUserDeviceName());
+        String deviceName = device.getModelName();
+        String friendlyName = device.getUserDeviceName();
+        if (friendlyName != null && !friendlyName.isEmpty()) {
+            deviceName = friendlyName + " (" + deviceName + ")";
+        }
+        holder.mText1.setText(deviceName); //device.getUserDeviceName());
         holder.mText2.setText("SN: " + device.getSerialNumber());
 
         if (connectedDevice != null && device.getSerialNumber().equals(connectedDevice.getSerialNumber())) {

--- a/app/src/main/java/wseemann/media/romote/fragment/ConfigureDeviceFragment.java
+++ b/app/src/main/java/wseemann/media/romote/fragment/ConfigureDeviceFragment.java
@@ -166,7 +166,12 @@ public class ConfigureDeviceFragment extends Fragment implements LoaderManager.L
                 TextView text1 = (TextView) view.findViewById(android.R.id.text1);
                 TextView text2 = (TextView) view.findViewById(android.R.id.text2);
 
-                text1.setText(devices.get(i).getModelName());
+                String deviceName = devices.get(i).getModelName();
+                String friendlyName = devices.get(i).getUserDeviceName();
+                if (friendlyName != null && !friendlyName.isEmpty()) {
+                    deviceName = friendlyName + " (" + deviceName + ")";
+                }
+                text1.setText(deviceName);
                 text2.setText("SN: " + devices.get(i).getSerialNumber());
 
                 view.setTag(devices.get(i));


### PR DESCRIPTION
Unfortunately I do not have the capability to test, but perhaps this helps. If there is a non-empty user-device-name, the display is "user-device-name (model-name)" -- otherwise it uses the current behavior of "model-name"

This should resolve issue #5