### PR TITLE
Support for landscape orientation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,7 +24,6 @@
         <activity
             android:name="wseemann.media.romote.activity.MainActivity"
             android:windowSoftInputMode="stateAlwaysHidden|adjustPan"
-            android:screenOrientation="portrait"
             android:configChanges="orientation|keyboardHidden"
             android:launchMode="singleTask"
             android:exported="true"
@@ -59,32 +58,27 @@
         <activity
             android:name="wseemann.media.romote.activity.RemoteActivity"
             android:theme="@style/AppTheme"
-            android:screenOrientation="portrait"
             android:configChanges="orientation|keyboardHidden"/>
 
         <activity
             android:name="wseemann.media.romote.activity.DeviceInfoActivity"
             android:theme="@style/AppTheme"
             android:label="@string/title_device_info"
-            android:screenOrientation="portrait"
             android:configChanges="orientation|keyboardHidden"/>
 
         <activity
             android:name="wseemann.media.romote.activity.SettingsActivity"
             android:theme="@style/AppTheme"
             android:label="@string/title_settings"
-            android:screenOrientation="portrait"
             android:configChanges="orientation|keyboardHidden"/>
 
         <activity
             android:name="wseemann.media.romote.activity.ConfigureDeviceActivity"
             android:theme="@style/AppTheme"
-            android:screenOrientation="portrait"
             android:configChanges="orientation|keyboardHidden"/>
 
         <activity android:name="wseemann.media.romote.activity.AppWidgetConfigure"
             android:theme="@style/AppTheme"
-            android:screenOrientation="portrait"
             android:configChanges="orientation|keyboardHidden"
             android:exported="true">
             <intent-filter>
@@ -96,7 +90,6 @@
             android:name="wseemann.media.romote.activity.ManualConnectionActivity"
             android:theme="@style/AppTheme"
             android:label="@string/title_connect_manually"
-            android:screenOrientation="portrait"
             android:configChanges="orientation|keyboardHidden"/>
 
         <receiver android:name="wseemann.media.romote.widget.RokuAppWidgetProvider"

--- a/app/src/main/java/wseemann/media/romote/activity/MainActivity.java
+++ b/app/src/main/java/wseemann/media/romote/activity/MainActivity.java
@@ -8,6 +8,7 @@ import android.content.SharedPreferences;
 import android.os.IBinder;
 
 import android.os.Bundle;
+import android.os.Handler;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -59,6 +60,14 @@ public class MainActivity extends ConnectivityActivity implements
     private ChannelFragment mChannelFragment;
 
     @Override
+    public Object onRetainCustomNonConfigurationInstance() {
+        if (mViewPager == null) {
+            return null;
+        }
+        return new Integer(mViewPager.getCurrentItem());
+    }
+
+    @Override
     public void onCreate(Bundle savedInstanceState) {
         SplashScreen.installSplashScreen(this);
         super.onCreate(savedInstanceState);
@@ -98,12 +107,22 @@ public class MainActivity extends ConnectivityActivity implements
             }
         });
 
-        if (!commandHelper.getDeviceURL().equals("")) {
-            mViewPager.setCurrentItem(1);
-        }
-
         TabLayout tabLayout = (TabLayout) findViewById(R.id.tabs);
         tabLayout.setupWithViewPager(mViewPager);
+
+        Integer lastItem = (Integer) getLastCustomNonConfigurationInstance();
+        if (lastItem != null) {
+            new Handler().post(new Runnable() {
+                    @Override
+                    public void run() {
+                        mViewPager.setCurrentItem(lastItem, false);
+                    }
+                });
+        } else {
+            if (!commandHelper.getDeviceURL().equals("")) {
+                mViewPager.setCurrentItem(1, false);
+            }
+        }
 
         /*BottomNavigationView bottomNavigationView = findViewById(R.id.bottom_navigation);
         bottomNavigationView.setLabelVisibilityMode(LabelVisibilityMode.LABEL_VISIBILITY_LABELED);

--- a/app/src/main/res/layout-w960dp/fragment_remote.xml
+++ b/app/src/main/res/layout-w960dp/fragment_remote.xml
@@ -225,6 +225,7 @@
                         android:layout_marginRight="10dp">
 
                         <include layout="@layout/remote_dpad_controls_view" />
+
                     </FrameLayout>
 
                     <ImageView
@@ -235,6 +236,7 @@
                         android:contentDescription="@null"
                         android:scaleType="fitCenter"
                             app:srcCompat="@mipmap/remote_dpad_bg" />
+
                 </RelativeLayout>
 
                 <RelativeLayout
@@ -260,7 +262,9 @@
                      android:text="@string/remote_gesture_text"
                      android:textColor="@android:color/transparent"
                      android:textSize="@dimen/font_size_15sp" />-->
+
                 </RelativeLayout>
+
             </ViewFlipper>
 
             <LinearLayout

--- a/app/src/main/res/layout-w960dp/fragment_remote.xml
+++ b/app/src/main/res/layout-w960dp/fragment_remote.xml
@@ -1,0 +1,299 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/remote_bg">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="horizontal">
+
+        <LinearLayout
+            android:layout_weight="1"
+            android:layout_width="0dip"
+            android:layout_height="match_parent"
+            android:orientation="vertical">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dip"
+                android:layout_marginLeft="20dip"
+                android:layout_marginRight="20dip"
+                android:orientation="horizontal">
+
+                <LinearLayout
+                    android:layout_weight="1"
+                    android:layout_width="0dip"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+	            </LinearLayout>
+
+                <wseemann.media.romote.view.VibratingImageButton
+	                android:id="@+id/power_button"
+	                android:layout_width="52dip"
+	                android:layout_height="52dip"
+	                android:background="@drawable/remote_button_bg"
+	                android:scaleType="center"
+	                android:src="@mipmap/remote_power" />
+
+                <TextView
+                    android:id="@+id/roku_device_name"
+                    android:layout_weight="1"
+                    android:layout_width="0dip"
+                    android:layout_height="@dimen/remote_view_top_title_height"
+                    android:paddingLeft="12dp"
+                    android:paddingTop="6dp"
+                    android:paddingRight="30dp"
+                    android:ellipsize="end"
+                    android:maxLines="1"
+                    android:textColor="@android:color/white"
+                    android:textSize="@dimen/font_size_18sp"
+                    android:background="@android:color/transparent" />
+
+	        </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/volume_controls"
+                android:layout_width="match_parent"
+                android:layout_height="52dip"
+                android:layout_marginTop="10dip"
+                android:layout_marginBottom="10dip"
+                android:layout_marginLeft="20dip"
+                android:layout_marginRight="20dip"
+                android:orientation="horizontal">
+
+                <wseemann.media.romote.view.VibratingImageButton
+                    android:id="@+id/mute_button"
+                    android:layout_width="0dip"
+                    android:layout_height="fill_parent"
+                    android:layout_marginRight="10dip"
+                    android:layout_weight="1"
+                    android:background="@drawable/remote_button_bg"
+                    android:src="@mipmap/remote_vol_mute" />
+
+                <wseemann.media.romote.view.VibratingImageButton
+                    android:id="@+id/volume_down_button"
+                    android:layout_width="0dip"
+                    android:layout_height="fill_parent"
+                    android:layout_gravity="center"
+                    android:layout_marginLeft="10dip"
+                    android:layout_marginRight="10dip"
+                    android:layout_weight="1"
+                    android:background="@drawable/remote_button_bg"
+                    android:contentDescription="@string/keyboard"
+                    android:src="@mipmap/remote_vol_down" />
+
+                <wseemann.media.romote.view.VibratingImageButton
+                    android:id="@+id/volume_up_button"
+                    android:layout_width="0dip"
+                    android:layout_height="fill_parent"
+                    android:layout_marginLeft="10dip"
+                    android:layout_weight="1"
+                    android:background="@drawable/remote_button_bg"
+                    android:src="@mipmap/remote_vol_up" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="52dip"
+                android:layout_marginTop="10dip"
+                android:layout_marginLeft="20dip"
+                android:layout_marginRight="20dip"
+                android:orientation="horizontal">
+
+                <wseemann.media.romote.view.VibratingImageButton
+                    android:id="@+id/rev_button"
+                    android:layout_width="0dip"
+                    android:layout_height="fill_parent"
+                    android:layout_marginRight="10dip"
+                    android:layout_weight="1"
+                    android:background="@drawable/remote_button_bg"
+                    android:src="@mipmap/remote_rw" />
+
+                <wseemann.media.romote.view.VibratingImageButton
+                    android:id="@+id/play_button"
+                    android:layout_width="0dip"
+                    android:layout_height="fill_parent"
+                    android:layout_marginLeft="10dip"
+                    android:layout_marginRight="10dip"
+                    android:layout_weight="2"
+                    android:background="@drawable/remote_button_bg"
+                    android:src="@mipmap/remote_playpause" />
+
+                <wseemann.media.romote.view.VibratingImageButton
+                    android:id="@+id/fwd_button"
+                    android:layout_width="0dip"
+                    android:layout_height="fill_parent"
+                    android:layout_marginLeft="10dip"
+                    android:layout_weight="1"
+                    android:background="@drawable/remote_button_bg"
+                    android:src="@mipmap/remote_ff" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="52dip"
+                android:layout_marginTop="10dip"
+                android:layout_marginBottom="10dip"
+                android:layout_marginLeft="20dip"
+                android:layout_marginRight="20dip"
+                android:orientation="horizontal">
+
+                <wseemann.media.romote.view.VibratingImageButton
+                    android:id="@+id/keyboard_button"
+                    android:layout_width="0dip"
+                    android:layout_height="fill_parent"
+                    android:layout_gravity="center"
+                    android:layout_marginRight="10dip"
+                    android:layout_weight="1"
+                    android:background="@drawable/remote_button_bg"
+                    android:contentDescription="@string/keyboard"
+                    android:src="@mipmap/remote_keyboard_2" />
+
+                <wseemann.media.romote.view.VibratingImageButton
+                    android:id="@+id/remote_audio"
+                    android:layout_width="0dip"
+                    android:layout_height="fill_parent"
+                    android:layout_marginLeft="10dip"
+                    android:layout_weight="1"
+                    android:background="@drawable/remote_button_bg"
+                    android:src="@mipmap/remote_private_listening_available" />
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_weight="1"
+            android:layout_width="0dip"
+            android:layout_height="match_parent"
+            android:orientation="vertical">
+	        
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="52dip"
+                android:layout_marginTop="10dip"
+                android:layout_marginLeft="20dip"
+                android:layout_marginRight="20dip"
+                android:orientation="horizontal">
+
+                <wseemann.media.romote.view.VibratingImageButton
+                    android:id="@+id/back_button"
+                    android:layout_width="0dip"
+                    android:layout_height="match_parent"
+                    android:layout_marginRight="10dip"
+                    android:layout_weight="1"
+                    android:background="@drawable/remote_button_bg"
+                    android:src="@mipmap/remote_back" />
+
+                <wseemann.media.romote.view.VibratingImageButton
+                    android:id="@+id/home_button"
+                    android:layout_width="0dip"
+                    android:layout_height="match_parent"
+                    android:layout_marginLeft="10dip"
+                    android:layout_weight="1"
+                    android:background="@drawable/remote_button_bg"
+                    android:src="@mipmap/remote_home" />
+
+            </LinearLayout>
+
+            <ViewFlipper
+                android:id="@+id/remote_dpad_flipper"
+                android:layout_width="wrap_content"
+                android:layout_height="0dp"
+                android:layout_weight="50"
+                android:paddingLeft="30dp"
+                android:paddingTop="10dp"
+                android:paddingRight="30dp">
+
+                <RelativeLayout
+                    android:id="@+id/dpad_section"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent">
+
+                    <FrameLayout
+                        android:id="@+id/remote_dpad_controls"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:layout_marginLeft="10dp"
+                        android:layout_marginRight="10dp">
+
+                        <include layout="@layout/remote_dpad_controls_view" />
+                    </FrameLayout>
+
+                    <ImageView
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:layout_centerInParent="true"
+                        android:adjustViewBounds="true"
+                        android:contentDescription="@null"
+                        android:scaleType="fitCenter"
+                            app:srcCompat="@mipmap/remote_dpad_bg" />
+                </RelativeLayout>
+
+                <RelativeLayout
+                    android:id="@+id/gestureArea"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent">
+
+                    <ImageView
+                        android:id="@+id/remote_dpad_swipe"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent"
+                        android:layout_centerInParent="true"
+                        android:adjustViewBounds="true"
+                        android:contentDescription="@null"
+                        android:scaleType="fitCenter"
+                            app:srcCompat="@android:color/transparent" />
+
+                    <!-- <TextView
+                     android:layout_width="match_parent"
+                     android:layout_height="match_parent"
+                     android:contentDescription="@null"
+                     android:gravity="center"
+                     android:text="@string/remote_gesture_text"
+                     android:textColor="@android:color/transparent"
+                     android:textSize="@dimen/font_size_15sp" />-->
+                </RelativeLayout>
+            </ViewFlipper>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="52dip"
+                android:layout_marginTop="10dip"
+                android:layout_marginBottom="10dip"
+                android:layout_marginLeft="20dip"
+                android:layout_marginRight="20dip"
+                android:orientation="horizontal">
+
+                <wseemann.media.romote.view.VibratingImageButton
+                    android:id="@+id/instant_replay_button"
+                    android:layout_width="0dip"
+                    android:layout_height="fill_parent"
+                    android:layout_marginRight="10dip"
+                    android:layout_weight="1"
+                    android:background="@drawable/remote_button_bg"
+                    android:src="@mipmap/remote_replay" />
+
+                <wseemann.media.romote.view.VibratingImageButton
+                    android:id="@+id/info_button"
+                    android:layout_width="0dip"
+                    android:layout_height="match_parent"
+                    android:layout_marginLeft="10dip"
+                    android:layout_weight="1"
+                    android:background="@drawable/remote_button_bg"
+                    android:src="@mipmap/remote_options" />
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+    </LinearLayout>
+	
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
I use my tablet in landscape mode all of the time, supported on top of the keyboard. Applications that don't support a landscape orientation can be quite irritating to me, so I enabled the landscape orientation on the activites and wrote an alternate layout for a landscape orientation on big screens to make better use of the screen real estate. The other views look fine on landscape, so no changes were needed there.

![Screenshot_20241222_124930_wseemann media romote](https://github.com/user-attachments/assets/1da7759d-89df-4b24-b54c-6672d28fd7d2)

A pending issue is a remote controller layout that works well with small screens on landscape. I suppose we would have to get rid of the tab switcher (or make it vertical) and the top title to maximize the area available for the buttons.
