### PR TITLE
README.md: added observation to enable ECP on Roku device.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # RoMote
+
 Open source Roku remote. Turn your Android Device into a control center for your Roku Player and Roku TV.
 
 <a href="https://f-droid.org/packages/wseemann.media.romote" target="_blank">
 <img src="https://f-droid.org/badge/get-it-on.png" alt="Get it on F-Droid" height="90"/></a>
 <a href="https://play.google.com/store/apps/details?id=wseemann.media.romote" target="_blank">
 <img src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" alt="Get it on Google Play" height="90"/></a>
+
+If RoMote fails to detect your Roku device or send commands to it,
+make sure the **Control by mobile apps** setting in your Roku [is
+enabled](https://support.roku.com/article/217288467#section-2).
 
 Privacy
 -------

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # RoMote
-
 Open source Roku remote. Turn your Android Device into a control center for your Roku Player and Roku TV.
 
 <a href="https://f-droid.org/packages/wseemann.media.romote" target="_blank">


### PR DESCRIPTION
Although many users may never come to see this as they will be getting the software from an app store. Maybe add this kind of text to the application description for the store.

I just saw that Roku disabling ECP by default on recent updates creating confusion among users, so I thought it would be useful to make them aware of the situation.