### PR TITLE
Use keyup/keydown ECP commands instead of keypress for a smoother operation.

### DIFF
--- a/app/src/main/java/wseemann/media/romote/fragment/RemoteFragment.java
+++ b/app/src/main/java/wseemann/media/romote/fragment/RemoteFragment.java
@@ -57,7 +57,6 @@ import wseemann.media.romote.utils.BroadcastUtils;
 import wseemann.media.romote.utils.CommandHelper;
 import wseemann.media.romote.utils.Constants;
 import wseemann.media.romote.utils.PreferenceUtils;
-import wseemann.media.romote.view.RepeatingImageButton;
 import wseemann.media.romote.view.VibratingImageButton;
 
 /**
@@ -105,25 +104,25 @@ public class RemoteFragment extends Fragment {
         });
         mVoiceSearcButton.requestFocus();*/
 
-        linkRepeatingRemoteButton(KeyPressKeyValues.BACK, R.id.back_button);
-        linkRepeatingRemoteButton(KeyPressKeyValues.UP, R.id.up_button);
-        linkRepeatingRemoteButton(KeyPressKeyValues.HOME, R.id.home_button);
+        linkButton(KeyPressKeyValues.BACK, R.id.back_button);
+        linkButton(KeyPressKeyValues.UP, R.id.up_button);
+        linkButton(KeyPressKeyValues.HOME, R.id.home_button);
 
-        linkRepeatingRemoteButton(KeyPressKeyValues.LEFT, R.id.left_button);
-        linkRepeatingRemoteButton(KeyPressKeyValues.SELECT, R.id.ok_button);
-        linkRepeatingRemoteButton(KeyPressKeyValues.RIGHT, R.id.right_button);
+        linkButton(KeyPressKeyValues.LEFT, R.id.left_button);
+        linkButton(KeyPressKeyValues.SELECT, R.id.ok_button);
+        linkButton(KeyPressKeyValues.RIGHT, R.id.right_button);
 
-        linkRepeatingRemoteButton(KeyPressKeyValues.INTANT_REPLAY, R.id.instant_replay_button);
-        linkRepeatingRemoteButton(KeyPressKeyValues.DOWN, R.id.down_button);
-        linkRepeatingRemoteButton(KeyPressKeyValues.INFO, R.id.info_button);
+        linkButton(KeyPressKeyValues.INTANT_REPLAY, R.id.instant_replay_button);
+        linkButton(KeyPressKeyValues.DOWN, R.id.down_button);
+        linkButton(KeyPressKeyValues.INFO, R.id.info_button);
 
-        linkRepeatingRemoteButton(KeyPressKeyValues.REV, R.id.rev_button);
-        linkRepeatingRemoteButton(KeyPressKeyValues.PLAY, R.id.play_button);
-        linkRepeatingRemoteButton(KeyPressKeyValues.FWD, R.id.fwd_button);
+        linkButton(KeyPressKeyValues.REV, R.id.rev_button);
+        linkButton(KeyPressKeyValues.PLAY, R.id.play_button);
+        linkButton(KeyPressKeyValues.FWD, R.id.fwd_button);
 
-        linkRepeatingRemoteButton(KeyPressKeyValues.VOLUME_MUTE, R.id.mute_button);
-        linkRepeatingRemoteButton(KeyPressKeyValues.VOLUME_DOWN, R.id.volume_down_button);
-        linkRepeatingRemoteButton(KeyPressKeyValues.VOLUME_UP, R.id.volume_up_button);
+        linkButton(KeyPressKeyValues.VOLUME_MUTE, R.id.mute_button);
+        linkButton(KeyPressKeyValues.VOLUME_DOWN, R.id.volume_down_button);
+        linkButton(KeyPressKeyValues.VOLUME_UP, R.id.volume_up_button);
 
         ImageButton keyboardButton = getView().findViewById(R.id.keyboard_button);
         keyboardButton.setOnClickListener(view -> {
@@ -172,40 +171,35 @@ public class RemoteFragment extends Fragment {
         getActivity().unregisterReceiver(mUpdateReceiver);
     }
 
-    private void linkRepeatingRemoteButton(final KeyPressKeyValues keypressKeyValue, int id) {
+    private void linkButton(final KeyPressKeyValues keypressKeyValue, int id) {
         View button = getView().findViewById(id);
 
-	button.setOnTouchListener((view, event) -> {
-		switch(event.getAction()) {
-		case MotionEvent.ACTION_DOWN:
-		    performKeydown(keypressKeyValue);
-		    if (id == R.id.back_button ||
-			id == R.id.home_button ||
-			id == R.id.ok_button) {
-			BroadcastUtils.Companion.sendUpdateDeviceBroadcast(requireContext());
-		    }
-		    break;
-		case MotionEvent.ACTION_UP:
-		case MotionEvent.ACTION_CANCEL:
-		    performKeyup(keypressKeyValue);
-		    break;
-		}
-		return false;
-	    });
-    }
-
-    private void linkButton(final KeyPressKeyValues keypressKeyValue, int id) {
-        ImageButton button = getView().findViewById(id);
-
         button.setOnClickListener(view -> {
-            performKeypress(keypressKeyValue);
-
-            if (id == R.id.back_button ||
+                if (id == R.id.back_button ||
                     id == R.id.home_button ||
                     id == R.id.ok_button) {
-                BroadcastUtils.Companion.sendUpdateDeviceBroadcast(requireContext());
-            }
-        });
+                    BroadcastUtils.Companion.sendUpdateDeviceBroadcast(requireContext());
+                }
+                performKeypress(keypressKeyValue);
+            });
+
+        button.setOnTouchListener((view, event) -> {
+                switch(event.getAction()) {
+                case MotionEvent.ACTION_DOWN:
+                    performKeydown(keypressKeyValue);
+                    if (id == R.id.back_button ||
+                        id == R.id.home_button ||
+                        id == R.id.ok_button) {
+                        BroadcastUtils.Companion.sendUpdateDeviceBroadcast(requireContext());
+                    }
+                    break;
+                case MotionEvent.ACTION_UP:
+                case MotionEvent.ACTION_CANCEL:
+                    performKeyup(keypressKeyValue);
+                    break;
+                }
+                return false;
+            });
     }
 
     private void performRequest(final ECPRequest<Void> request) {

--- a/app/src/main/java/wseemann/media/romote/fragment/RemoteFragment.java
+++ b/app/src/main/java/wseemann/media/romote/fragment/RemoteFragment.java
@@ -23,6 +23,7 @@ import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageButton;
@@ -36,7 +37,10 @@ import androidx.fragment.app.Fragment;
 
 import com.wseemann.ecp.api.ResponseCallback;
 import com.wseemann.ecp.core.KeyPressKeyValues;
+import com.wseemann.ecp.core.ECPRequest;
 import com.wseemann.ecp.request.KeyPressRequest;
+import com.wseemann.ecp.request.KeyupRequest;
+import com.wseemann.ecp.request.KeydownRequest;
 import com.wseemann.ecp.request.QueryDeviceInfoRequest;
 
 import java.util.List;
@@ -171,11 +175,18 @@ public class RemoteFragment extends Fragment {
     private void linkRepeatingRemoteButton(final KeyPressKeyValues keypressKeyValue, int id) {
         RepeatingImageButton button = getView().findViewById(id);
 
-        button.setOnClickListener(view -> {
-            performKeypress(keypressKeyValue);
-        });
-
-        button.setRepeatListener((v, duration, repeatcount) -> performKeypress(keypressKeyValue), 400);
+	button.setOnTouchListener((view, event) -> {
+		switch(event.getAction()) {
+		case MotionEvent.ACTION_DOWN:
+		    performKeydown(keypressKeyValue);
+		    break;
+		case MotionEvent.ACTION_UP:
+		case MotionEvent.ACTION_CANCEL:
+		    performKeyup(keypressKeyValue);
+		    break;
+		}
+		return false;
+	    });
     }
 
     private void linkButton(final KeyPressKeyValues keypressKeyValue, int id) {
@@ -192,7 +203,7 @@ public class RemoteFragment extends Fragment {
         });
     }
 
-    private void performRequest(final KeyPressRequest request) {
+    private void performRequest(final ECPRequest<Void> request) {
         request.sendAsync(new ResponseCallback<>() {
             @Override
             public void onSuccess(@Nullable Void unused) {
@@ -255,6 +266,20 @@ public class RemoteFragment extends Fragment {
 
         KeyPressRequest keyPressRequest = new KeyPressRequest(url, keypressKeyValue.getValue());
         performRequest(keyPressRequest);
+    }
+
+    private void performKeydown(KeyPressKeyValues keypressKeyValue) {
+        String url = commandHelper.getDeviceURL();
+
+        KeydownRequest keydownRequest = new KeydownRequest(url, keypressKeyValue.getValue());
+        performRequest(keydownRequest);
+    }
+
+    private void performKeyup(KeyPressKeyValues keypressKeyValue) {
+        String url = commandHelper.getDeviceURL();
+
+        KeyupRequest keyupRequest = new KeyupRequest(url, keypressKeyValue.getValue());
+        performRequest(keyupRequest);
     }
 
     @Override

--- a/app/src/main/java/wseemann/media/romote/fragment/RemoteFragment.java
+++ b/app/src/main/java/wseemann/media/romote/fragment/RemoteFragment.java
@@ -105,25 +105,25 @@ public class RemoteFragment extends Fragment {
         });
         mVoiceSearcButton.requestFocus();*/
 
-        linkButton(KeyPressKeyValues.BACK, R.id.back_button);
+        linkRepeatingRemoteButton(KeyPressKeyValues.BACK, R.id.back_button);
         linkRepeatingRemoteButton(KeyPressKeyValues.UP, R.id.up_button);
-        linkButton(KeyPressKeyValues.HOME, R.id.home_button);
+        linkRepeatingRemoteButton(KeyPressKeyValues.HOME, R.id.home_button);
 
         linkRepeatingRemoteButton(KeyPressKeyValues.LEFT, R.id.left_button);
-        linkButton(KeyPressKeyValues.SELECT, R.id.ok_button);
+        linkRepeatingRemoteButton(KeyPressKeyValues.SELECT, R.id.ok_button);
         linkRepeatingRemoteButton(KeyPressKeyValues.RIGHT, R.id.right_button);
 
-        linkButton(KeyPressKeyValues.INTANT_REPLAY, R.id.instant_replay_button);
+        linkRepeatingRemoteButton(KeyPressKeyValues.INTANT_REPLAY, R.id.instant_replay_button);
         linkRepeatingRemoteButton(KeyPressKeyValues.DOWN, R.id.down_button);
-        linkButton(KeyPressKeyValues.INFO, R.id.info_button);
+        linkRepeatingRemoteButton(KeyPressKeyValues.INFO, R.id.info_button);
 
-        linkButton(KeyPressKeyValues.REV, R.id.rev_button);
-        linkButton(KeyPressKeyValues.PLAY, R.id.play_button);
-        linkButton(KeyPressKeyValues.FWD, R.id.fwd_button);
+        linkRepeatingRemoteButton(KeyPressKeyValues.REV, R.id.rev_button);
+        linkRepeatingRemoteButton(KeyPressKeyValues.PLAY, R.id.play_button);
+        linkRepeatingRemoteButton(KeyPressKeyValues.FWD, R.id.fwd_button);
 
-        linkButton(KeyPressKeyValues.VOLUME_MUTE, R.id.mute_button);
-        linkButton(KeyPressKeyValues.VOLUME_DOWN, R.id.volume_down_button);
-        linkButton(KeyPressKeyValues.VOLUME_UP, R.id.volume_up_button);
+        linkRepeatingRemoteButton(KeyPressKeyValues.VOLUME_MUTE, R.id.mute_button);
+        linkRepeatingRemoteButton(KeyPressKeyValues.VOLUME_DOWN, R.id.volume_down_button);
+        linkRepeatingRemoteButton(KeyPressKeyValues.VOLUME_UP, R.id.volume_up_button);
 
         ImageButton keyboardButton = getView().findViewById(R.id.keyboard_button);
         keyboardButton.setOnClickListener(view -> {
@@ -173,12 +173,17 @@ public class RemoteFragment extends Fragment {
     }
 
     private void linkRepeatingRemoteButton(final KeyPressKeyValues keypressKeyValue, int id) {
-        RepeatingImageButton button = getView().findViewById(id);
+        View button = getView().findViewById(id);
 
 	button.setOnTouchListener((view, event) -> {
 		switch(event.getAction()) {
 		case MotionEvent.ACTION_DOWN:
 		    performKeydown(keypressKeyValue);
+		    if (id == R.id.back_button ||
+			id == R.id.home_button ||
+			id == R.id.ok_button) {
+			BroadcastUtils.Companion.sendUpdateDeviceBroadcast(requireContext());
+		    }
 		    break;
 		case MotionEvent.ACTION_UP:
 		case MotionEvent.ACTION_CANCEL:

--- a/app/src/main/java/wseemann/media/romote/fragment/RemoteFragment.java
+++ b/app/src/main/java/wseemann/media/romote/fragment/RemoteFragment.java
@@ -186,12 +186,12 @@ public class RemoteFragment extends Fragment {
         button.setOnTouchListener((view, event) -> {
                 switch(event.getAction()) {
                 case MotionEvent.ACTION_DOWN:
-                    performKeydown(keypressKeyValue);
                     if (id == R.id.back_button ||
                         id == R.id.home_button ||
                         id == R.id.ok_button) {
                         BroadcastUtils.Companion.sendUpdateDeviceBroadcast(requireContext());
                     }
+                    performKeydown(keypressKeyValue);
                     break;
                 case MotionEvent.ACTION_UP:
                 case MotionEvent.ACTION_CANCEL:

--- a/app/src/main/java/wseemann/media/romote/utils/ViewUtils.java
+++ b/app/src/main/java/wseemann/media/romote/utils/ViewUtils.java
@@ -20,11 +20,12 @@ public class ViewUtils {
     }
 
     private static Vibrator getVibrator(View view) {
-        if (!CommonModule.PreferenceUtilsSingleton.preferenceUtils.shouldProvideHapticFeedback()) {
+        if (!CommonModule.PreferenceUtilsSingleton.preferenceUtils.shouldProvideHapticFeedback())
             return null;
-        }
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            VibratorManager vibratorManager = (VibratorManager) view.getContext().getSystemService(Context.VIBRATOR_MANAGER_SERVICE);
+            VibratorManager vibratorManager = (VibratorManager) view.getContext()
+                .getSystemService(Context.VIBRATOR_MANAGER_SERVICE);
             return vibratorManager.getDefaultVibrator();
         }
         return (Vibrator) view.getContext().getSystemService(Context.VIBRATOR_SERVICE);
@@ -33,21 +34,18 @@ public class ViewUtils {
     // effect: use one of android.os.VibrationEffect
     public static void provideHapticEffect(View view, int effect_id, int fallbackVibrateDurationMs) {
         Vibrator vibrator = getVibrator(view);
-        if (vibrator == null) {
+        if (vibrator == null)
             return;
-        }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             VibrationEffect effect;
-            if (effect_id == VibrationEffect.DEFAULT_AMPLITUDE) {
+            if (effect_id == VibrationEffect.DEFAULT_AMPLITUDE)
                 effect = VibrationEffect.createOneShot(fallbackVibrateDurationMs, effect_id);
-            } else {
+            else
                 effect = VibrationEffect.createPredefined(effect_id);
-            }
             vibrator.vibrate(effect);
-        } else {
+        } else
             vibrator.vibrate(fallbackVibrateDurationMs); 
-       }
     }
 
     public static void provideHapticFeedback(View view, int vibrateDurationMs) {

--- a/app/src/main/java/wseemann/media/romote/utils/ViewUtils.java
+++ b/app/src/main/java/wseemann/media/romote/utils/ViewUtils.java
@@ -19,16 +19,38 @@ public class ViewUtils {
 
     }
 
-    public static void provideHapticFeedback(View view, int vibrateDurationMs) {
-        if (CommonModule.PreferenceUtilsSingleton.preferenceUtils.shouldProvideHapticFeedback()) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                VibratorManager vibratorManager = (VibratorManager) view.getContext().getSystemService(Context.VIBRATOR_MANAGER_SERVICE);
-                Vibrator vibrator = vibratorManager.getDefaultVibrator();
-                vibrator.vibrate(VibrationEffect.createOneShot(vibrateDurationMs,VibrationEffect.DEFAULT_AMPLITUDE));
-            } else {
-                Vibrator vibrator = (Vibrator) view.getContext().getSystemService(Context.VIBRATOR_SERVICE);
-                vibrator.vibrate(vibrateDurationMs);
-            }
+    private static Vibrator getVibrator(View view) {
+        if (!CommonModule.PreferenceUtilsSingleton.preferenceUtils.shouldProvideHapticFeedback()) {
+            return null;
         }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            VibratorManager vibratorManager = (VibratorManager) view.getContext().getSystemService(Context.VIBRATOR_MANAGER_SERVICE);
+            return vibratorManager.getDefaultVibrator();
+        }
+        return (Vibrator) view.getContext().getSystemService(Context.VIBRATOR_SERVICE);
+    }
+
+    // effect: use one of android.os.VibrationEffect
+    public static void provideHapticEffect(View view, int effect_id, int fallbackVibrateDurationMs) {
+        Vibrator vibrator = getVibrator(view);
+        if (vibrator == null) {
+            return;
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            VibrationEffect effect;
+            if (effect_id == VibrationEffect.DEFAULT_AMPLITUDE) {
+                effect = VibrationEffect.createOneShot(fallbackVibrateDurationMs, effect_id);
+            } else {
+                effect = VibrationEffect.createPredefined(effect_id);
+            }
+            vibrator.vibrate(effect);
+        } else {
+            vibrator.vibrate(fallbackVibrateDurationMs); 
+       }
+    }
+
+    public static void provideHapticFeedback(View view, int vibrateDurationMs) {
+        provideHapticEffect(view, VibrationEffect.DEFAULT_AMPLITUDE, vibrateDurationMs);
     }
 }

--- a/app/src/main/java/wseemann/media/romote/view/VibratingImageButton.java
+++ b/app/src/main/java/wseemann/media/romote/view/VibratingImageButton.java
@@ -30,12 +30,14 @@ public class VibratingImageButton extends AppCompatImageButton {
     public VibratingImageButton(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
         super.setOnClickListener((View view) -> {
-            if (mClickListener != null && !preventClick) {
-                ViewUtils.provideHapticEffect(view, VibrationEffect.EFFECT_TICK, VIBRATE_DURATION_MS);
-                mClickListener.onClick(view);
-            }
-            preventClick = false;
-        });
+                if (!preventClick) {
+                    ViewUtils.provideHapticEffect(view, VibrationEffect.EFFECT_TICK, VIBRATE_DURATION_MS);
+                    if (mClickListener != null) {
+                        mClickListener.onClick(view);
+                    }
+                }
+                preventClick = false;
+            });
 
         super.setOnTouchListener((View view, MotionEvent event) -> {
                 if (mTouchListener == null) {

--- a/app/src/main/java/wseemann/media/romote/view/VibratingImageButton.java
+++ b/app/src/main/java/wseemann/media/romote/view/VibratingImageButton.java
@@ -32,17 +32,15 @@ public class VibratingImageButton extends AppCompatImageButton {
         super.setOnClickListener((View view) -> {
                 if (!preventClick) {
                     ViewUtils.provideHapticEffect(view, VibrationEffect.EFFECT_TICK, VIBRATE_DURATION_MS);
-                    if (mClickListener != null) {
+                    if (mClickListener != null)
                         mClickListener.onClick(view);
-                    }
                 }
                 preventClick = false;
             });
 
         super.setOnTouchListener((View view, MotionEvent event) -> {
-                if (mTouchListener == null) {
+                if (mTouchListener == null)
                     return false;
-                }
 
                 switch(event.getAction()) {
                 case MotionEvent.ACTION_DOWN:

--- a/app/src/main/java/wseemann/media/romote/view/VibratingImageButton.java
+++ b/app/src/main/java/wseemann/media/romote/view/VibratingImageButton.java
@@ -1,8 +1,10 @@
 package wseemann.media.romote.view;
 
 import android.content.Context;
+import android.os.VibrationEffect;
 import android.util.AttributeSet;
 import android.view.View;
+import android.view.MotionEvent;
 
 import androidx.appcompat.widget.AppCompatImageButton;
 
@@ -10,9 +12,12 @@ import wseemann.media.romote.utils.ViewUtils;
 
 public class VibratingImageButton extends AppCompatImageButton {
 
-    private static final int VIBRATE_DURATION_MS = 100;
+    private static final int VIBRATE_DURATION_MS = 25;
 
-    private View.OnClickListener mListener;
+    private View.OnClickListener mClickListener;
+    private View.OnTouchListener mTouchListener;
+
+    private boolean preventClick = false;
 
     public VibratingImageButton(Context context) {
         this(context, null);
@@ -25,16 +30,38 @@ public class VibratingImageButton extends AppCompatImageButton {
     public VibratingImageButton(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
         super.setOnClickListener((View view) -> {
-            ViewUtils.provideHapticFeedback(view, VIBRATE_DURATION_MS);
-
-            if (mListener != null) {
-                mListener.onClick(view);
+            if (mClickListener != null && !preventClick) {
+                ViewUtils.provideHapticEffect(view, VibrationEffect.EFFECT_TICK, VIBRATE_DURATION_MS);
+                mClickListener.onClick(view);
             }
+            preventClick = false;
         });
+
+        super.setOnTouchListener((View view, MotionEvent event) -> {
+                switch(event.getAction()) {
+                case MotionEvent.ACTION_DOWN:
+                    ViewUtils.provideHapticEffect(view, VibrationEffect.EFFECT_TICK, VIBRATE_DURATION_MS);
+                    preventClick = true;
+                    break;
+                case MotionEvent.ACTION_CANCEL:
+                    preventClick = false;
+                    break;
+                }
+
+                if (mTouchListener != null) {
+                    return mTouchListener.onTouch(view, event);
+                }
+                return false;
+            });
     }
 
     @Override
     public void setOnClickListener(View.OnClickListener listener) {
-        mListener = listener;
+        mClickListener = listener;
+    }
+
+    @Override
+    public void setOnTouchListener(View.OnTouchListener listener) {
+        mTouchListener = listener;
     }
 }

--- a/app/src/main/java/wseemann/media/romote/view/VibratingImageButton.java
+++ b/app/src/main/java/wseemann/media/romote/view/VibratingImageButton.java
@@ -38,6 +38,10 @@ public class VibratingImageButton extends AppCompatImageButton {
         });
 
         super.setOnTouchListener((View view, MotionEvent event) -> {
+                if (mTouchListener == null) {
+                    return false;
+                }
+
                 switch(event.getAction()) {
                 case MotionEvent.ACTION_DOWN:
                     ViewUtils.provideHapticEffect(view, VibrationEffect.EFFECT_TICK, VIBRATE_DURATION_MS);
@@ -48,10 +52,7 @@ public class VibratingImageButton extends AppCompatImageButton {
                     break;
                 }
 
-                if (mTouchListener != null) {
-                    return mTouchListener.onTouch(view, event);
-                }
-                return false;
+                return mTouchListener.onTouch(view, event);
             });
     }
 

--- a/app/src/main/res/layout/remote_dpad_controls_view.xml
+++ b/app/src/main/res/layout/remote_dpad_controls_view.xml
@@ -16,7 +16,7 @@
             android:layout_height="match_parent"
             android:layout_weight="1" />
 
-        <wseemann.media.romote.view.RepeatingImageButton
+        <wseemann.media.romote.view.VibratingImageButton
             android:id="@+id/up_button"
             android:layout_width="0dp"
             android:layout_height="match_parent"
@@ -36,7 +36,7 @@
         android:layout_weight="1"
         android:orientation="horizontal">
 
-        <wseemann.media.romote.view.RepeatingImageButton
+        <wseemann.media.romote.view.VibratingImageButton
             android:id="@+id/left_button"
             android:layout_width="0dp"
             android:layout_height="match_parent"
@@ -52,7 +52,7 @@
             android:background="@drawable/background_glow_selector"
             android:tag="Select" />
 
-        <wseemann.media.romote.view.RepeatingImageButton
+        <wseemann.media.romote.view.VibratingImageButton
             android:id="@+id/right_button"
             android:layout_width="0dp"
             android:layout_height="match_parent"
@@ -72,7 +72,7 @@
             android:layout_height="match_parent"
             android:layout_weight="1" />
 
-        <wseemann.media.romote.view.RepeatingImageButton
+        <wseemann.media.romote.view.VibratingImageButton
             android:id="@+id/down_button"
             android:layout_width="0dp"
             android:layout_height="match_parent"


### PR DESCRIPTION
I first noticed there was a problem with RoMote when trying the Retaliate game on Roku, but I've seen that it affects more common use cases, such as doing ff or rew while playing a video on YouTube or any other player, or navigating quickly on content collections.

This patch changes RoMote so that it sends keyup/keydown commands instead of single kepress commands every 400ms.

RepeatingImageButton class is no longer used and all remote buttons use VibratingImageButton, which was modified to listen to Touch events. Click events are still handled in case the buttons are clicked using a non-touch device.

Haptic vibrations were retouched a bit, allowing for the new Effects API to be used, with a gracious fallback for older devices. The vibration is now more subtle, as they are now produced using EFFECT_TICK.