### PR TITLE
Catch UnsupportedEncodingException when creating new ECP key requests

### DIFF
--- a/app/src/main/java/wseemann/media/romote/activity/ShakeActivity.java
+++ b/app/src/main/java/wseemann/media/romote/activity/ShakeActivity.java
@@ -11,6 +11,8 @@ import com.wseemann.ecp.api.ResponseCallback;
 import com.wseemann.ecp.core.KeyPressKeyValues;
 import com.wseemann.ecp.request.KeyPressRequest;
 
+import java.io.UnsupportedEncodingException;
+
 import javax.inject.Inject;
 
 import dagger.hilt.android.AndroidEntryPoint;
@@ -57,7 +59,13 @@ public class ShakeActivity extends AppCompatActivity {
         public void onShake() {
             String url = commandHelper.getDeviceURL();
 
-            KeyPressRequest keyPressRequest = new KeyPressRequest(url, KeyPressKeyValues.PLAY.getValue());
+            KeyPressRequest keyPressRequest;
+            try {
+                keyPressRequest = new KeyPressRequest(url, KeyPressKeyValues.PLAY.getValue());
+            } catch (UnsupportedEncodingException ex) {
+                ex.printStackTrace();
+                return;
+            }
             keyPressRequest.sendAsync(new ResponseCallback<Void>() {
                 @Override
                 public void onSuccess(@Nullable Void unused) {

--- a/app/src/main/java/wseemann/media/romote/fragment/RemoteFragment.java
+++ b/app/src/main/java/wseemann/media/romote/fragment/RemoteFragment.java
@@ -1,5 +1,7 @@
 package wseemann.media.romote.fragment;
 
+import java.io.UnsupportedEncodingException;
+
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
@@ -253,7 +255,13 @@ public class RemoteFragment extends Fragment {
     private void performKeypress(KeyPressKeyValues keypressKeyValue) {
         String url = commandHelper.getDeviceURL();
 
-        KeyPressRequest keyPressRequest = new KeyPressRequest(url, keypressKeyValue.getValue());
+        KeyPressRequest keyPressRequest;
+        try {
+            keyPressRequest = new KeyPressRequest(url, keypressKeyValue.getValue());
+        } catch (UnsupportedEncodingException ex) {
+            ex.printStackTrace();
+            return;
+        }
         performRequest(keyPressRequest);
     }
 

--- a/app/src/main/java/wseemann/media/romote/fragment/SettingsFragment.java
+++ b/app/src/main/java/wseemann/media/romote/fragment/SettingsFragment.java
@@ -1,5 +1,7 @@
 package wseemann.media.romote.fragment;
 
+import java.io.UnsupportedEncodingException;
+
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
@@ -92,7 +94,13 @@ public class SettingsFragment extends PreferenceFragmentCompat
     private void performKeypress(KeyPressKeyValues keyPressKeyValue) {
         String url = commandHelper.getDeviceURL();
 
-        KeyPressRequest keypressRequest = new KeyPressRequest(url, keyPressKeyValue.getValue());
+        KeyPressRequest keypressRequest;
+        try {
+            keypressRequest = new KeyPressRequest(url, keyPressKeyValue.getValue());
+        } catch (UnsupportedEncodingException ex) {
+            ex.printStackTrace();
+            return;
+        }
         keypressRequest.sendAsync(new ResponseCallback<Void>() {
             @Override
             public void onSuccess(@Nullable Void unused) {

--- a/app/src/main/java/wseemann/media/romote/fragment/TextInputDialog.java
+++ b/app/src/main/java/wseemann/media/romote/fragment/TextInputDialog.java
@@ -1,5 +1,7 @@
 package wseemann.media.romote.fragment;
 
+import java.io.UnsupportedEncodingException;
+
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.Context;
@@ -175,7 +177,13 @@ public class TextInputDialog extends DialogFragment {
     private void sendBackspace() {
         String url = commandHelper.getDeviceURL();
 
-        KeyPressRequest keyPressRequest = new KeyPressRequest(url, KeyPressKeyValues.BACKSPACE.getValue());
+        KeyPressRequest keyPressRequest;
+        try {
+            keyPressRequest = new KeyPressRequest(url, KeyPressKeyValues.BACKSPACE.getValue());
+        } catch (UnsupportedEncodingException ex) {
+            ex.printStackTrace();
+            return;
+        }
         keyPressRequest.sendAsync(new ResponseCallback<Void>() {
             @Override
             public void onSuccess(@Nullable Void unused) {
@@ -192,7 +200,13 @@ public class TextInputDialog extends DialogFragment {
     private void sendStringLiteral(String stringLiteral) {
         String url = commandHelper.getDeviceURL();
 
-        KeyPressRequest keypressRequest = new KeyPressRequest(url, KeyPressKeyValues.LIT_.getValue() + stringLiteral);
+        KeyPressRequest keypressRequest;
+        try {
+            keypressRequest = new KeyPressRequest(url, KeyPressKeyValues.LIT_.getValue() + stringLiteral);
+        } catch (UnsupportedEncodingException ex) {
+            ex.printStackTrace();
+            return;
+        }
         keypressRequest.sendAsync(new ResponseCallback<Void>() {
             @Override
             public void onSuccess(@Nullable Void unused) {

--- a/app/src/main/java/wseemann/media/romote/receiver/CommandReceiver.java
+++ b/app/src/main/java/wseemann/media/romote/receiver/CommandReceiver.java
@@ -1,5 +1,7 @@
 package wseemann.media.romote.receiver;
 
+import java.io.UnsupportedEncodingException;
+
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -35,7 +37,14 @@ public class CommandReceiver extends BroadcastReceiver {
                 return;
             }
 
-            KeyPressRequest keypressRequest = new KeyPressRequest(url, keypressKeyValues.getValue());
+            KeyPressRequest keypressRequest;
+            try {
+                keypressRequest = new KeyPressRequest(url, keypressKeyValues.getValue());
+            } catch (UnsupportedEncodingException ex) {
+                ex.printStackTrace();
+                return;
+            }
+
             keypressRequest.sendAsync(new ResponseCallback<>() {
                 @Override
                 public void onSuccess(@Nullable Void unused) {

--- a/app/src/main/java/wseemann/media/romote/service/CommandService.java
+++ b/app/src/main/java/wseemann/media/romote/service/CommandService.java
@@ -1,5 +1,7 @@
 package wseemann.media.romote.service;
 
+import java.io.UnsupportedEncodingException;
+
 import android.app.IntentService;
 import android.content.Intent;
 import android.util.Log;
@@ -51,7 +53,13 @@ public class CommandService extends IntentService {
     private void performKeypress(KeyPressKeyValues keypressKeyValue) {
         String url = commandHelper.getDeviceURL();
 
-        KeyPressRequest keypressRequest = new KeyPressRequest(url, keypressKeyValue.getValue());
+        KeyPressRequest keypressRequest;
+        try {
+            keypressRequest = new KeyPressRequest(url, keypressKeyValue.getValue());
+        } catch (UnsupportedEncodingException ex) {
+            ex.printStackTrace();
+            return;
+        }
         keypressRequest.sendAsync(new ResponseCallback<Void>() {
             @Override
             public void onSuccess(@Nullable Void unused) {


### PR DESCRIPTION
and do a stack trace print, for all of the places where ECP key requests are instantiated.

This PR is a companion of https://github.com/wseemann/Roku-ECP-Wrapper-Kotlin/pull/2 PR